### PR TITLE
Load Template on Activate

### DIFF
--- a/src/vModal/services/vModal.js
+++ b/src/vModal/services/vModal.js
@@ -24,18 +24,18 @@ function vModalFactory ($animate, $compile, $rootScope, $controller, $q, $http, 
         html,
         scope;
 
-    if (config.template) {
-      html = $q.when(config.template);
-    } else {
-      html = $http.get(config.templateUrl, {
-        cache: $templateCache
-      }).
-      then(function (response) {
-        return response.data;
-      });
-    }
-
     function activate (locals) {
+      if (config.template) {
+        html = $q.when(config.template);
+      } else {
+        html = $http.get(config.templateUrl, {
+          cache: $templateCache
+        }).
+        then(function (response) {
+          return response.data;
+        });
+      }
+      
       return html.then(function (html) {
         if (!element) {
           attach(html, locals);


### PR DESCRIPTION
Apparently the modal will load everything in one go.
This commit removes the unnecessary and load during activation only.
